### PR TITLE
bitbang I2C running under Blinka did not work with the peripherals I tested.

### DIFF
--- a/adafruit_bitbangio.py
+++ b/adafruit_bitbangio.py
@@ -114,12 +114,12 @@ class I2C(_BitBangIO):
                     found.append(address)
         return found
 
-    def writeto(self, address, buffer, *, start=0, end=None, stop=True):
+    def writeto(self, address, buffer, *, start=0, end=None):
         """Write data from the buffer to an address"""
         if end is None:
             end = len(buffer)
         if self._check_lock():
-            self._write(address, buffer[start:end], stop)
+            self._write(address, buffer[start:end], True)
 
     def readfrom_into(self, address, buffer, *, start=0, end=None):
         """Read data from an address and into the buffer"""
@@ -150,7 +150,7 @@ class I2C(_BitBangIO):
         if in_end is None:
             in_end = len(buffer_in)
         if self._check_lock():
-            self.writeto(address, buffer_out, start=out_start, end=out_end, stop=False)
+            self._write(address, buffer[out_start:out_end], False)
             self.readfrom_into(address, buffer_in, start=in_start, end=in_end)
 
     def _scl_low(self):

--- a/adafruit_bitbangio.py
+++ b/adafruit_bitbangio.py
@@ -24,7 +24,7 @@ Implementation Notes
 """
 
 # imports
-from time import monotonic, sleep
+from time import monotonic
 from digitalio import DigitalInOut
 
 __version__ = "0.0.0-auto.0"
@@ -84,21 +84,26 @@ class I2C(_BitBangIO):
 
         # Set pins as outputs/inputs.
         self._scl = DigitalInOut(scl)
-        self._scl.switch_to_output()
-        self._scl.value = 1
+        # rpi gpio does not support OPEN_DRAIN, so we have to emulate it
+        # by setting the pin to input for high and output 0 for low
+        self._scl.switch_to_input()
 
         # SDA flips between being input and output
         self._sda = DigitalInOut(sda)
-        self._sda.switch_to_output()
-        self._sda.value = 1
+        self._sda.switch_to_input()
 
-        self._delay = 1 / frequency / 2
+        self._delay = (1 / frequency) / 2  # half period
         self._timeout = timeout
 
     def deinit(self):
         """Free any hardware used by the object."""
         self._sda.deinit()
         self._scl.deinit()
+
+    def _wait(self):
+        end = monotonic() + self._delay  # half period
+        while end > monotonic():
+            pass
 
     def scan(self):
         """Perform an I2C Device Scan"""
@@ -109,12 +114,12 @@ class I2C(_BitBangIO):
                     found.append(address)
         return found
 
-    def writeto(self, address, buffer, *, start=0, end=None):
+    def writeto(self, address, buffer, *, start=0, end=None, stop=True):
         """Write data from the buffer to an address"""
         if end is None:
             end = len(buffer)
         if self._check_lock():
-            self._write(address, buffer[start:end], True)
+            self._write(address, buffer[start:end], stop)
 
     def readfrom_into(self, address, buffer, *, start=0, end=None):
         """Read data from an address and into the buffer"""
@@ -145,100 +150,100 @@ class I2C(_BitBangIO):
         if in_end is None:
             in_end = len(buffer_in)
         if self._check_lock():
-            self.writeto(address, buffer_out, start=out_start, end=out_end)
+            self.writeto(address, buffer_out, start=out_start, end=out_end, stop=False)
             self.readfrom_into(address, buffer_in, start=in_start, end=in_end)
 
     def _scl_low(self):
-        self._scl.value = 0
+        self._scl.switch_to_output(value=False)
 
     def _sda_low(self):
-        self._sda.value = 0
+        self._sda.switch_to_output(value=False)
 
     def _scl_release(self):
         """Release and let the pullups lift"""
         # Use self._timeout to add clock stretching
-        self._scl.value = 1
+        self._scl.switch_to_input()
 
     def _sda_release(self):
         """Release and let the pullups lift"""
         # Use self._timeout to add clock stretching
-        self._sda.value = 1
+        self._sda.switch_to_input()
 
     def _start(self):
         self._sda_release()
         self._scl_release()
-        sleep(self._delay)
+        self._wait()
         self._sda_low()
-        sleep(self._delay)
+        self._wait()
 
     def _stop(self):
         self._scl_low()
-        sleep(self._delay)
+        self._wait()
         self._sda_low()
-        sleep(self._delay)
+        self._wait()
         self._scl_release()
-        sleep(self._delay)
+        self._wait()
         self._sda_release()
-        sleep(self._delay)
+        self._wait()
 
     def _repeated_start(self):
         self._scl_low()
-        sleep(self._delay)
+        self._wait()
         self._sda_release()
-        sleep(self._delay)
+        self._wait()
         self._scl_release()
-        sleep(self._delay)
+        self._wait()
         self._sda_low()
-        sleep(self._delay)
+        self._wait()
 
     def _write_byte(self, byte):
         for bit_position in range(8):
             self._scl_low()
-            sleep(self._delay)
+
             if byte & (0x80 >> bit_position):
                 self._sda_release()
             else:
                 self._sda_low()
-            sleep(self._delay)
+            self._wait()
             self._scl_release()
-            sleep(self._delay)
+            self._wait()
+
         self._scl_low()
-        sleep(self._delay * 2)
+        self._sda.switch_to_input()  # SDA may go high, but SCL is low
+        self._wait()
 
         self._scl_release()
-        sleep(self._delay)
-
-        self._sda.switch_to_input()
-        ack = self._sda.value
-        self._sda.switch_to_output()
-        sleep(self._delay)
+        self._wait()
+        ack = self._sda.value  # read the ack
 
         self._scl_low()
+        self._sda_release()
+        self._wait()
 
         return not ack
 
     def _read_byte(self, ack=False):
         self._scl_low()
-        sleep(self._delay)
-
+        self._wait()
+        # sda will already be an input as we are simulating open drain
         data = 0
-        self._sda.switch_to_input()
         for _ in range(8):
             self._scl_release()
-            sleep(self._delay)
+            self._wait()
             data = (data << 1) | int(self._sda.value)
-            sleep(self._delay)
             self._scl_low()
-            sleep(self._delay)
-        self._sda.switch_to_output()
+            self._wait()
 
         if ack:
             self._sda_low()
-        else:
-            self._sda_release()
-        sleep(self._delay)
+        # else sda will already be in release (open drain) mode
+
+        self._wait()
         self._scl_release()
-        sleep(self._delay)
+        self._wait()
+        self._scl_low()
+        self._sda_release()
+
         return data & 0xFF
 
     def _probe(self, address):

--- a/adafruit_bitbangio.py
+++ b/adafruit_bitbangio.py
@@ -150,7 +150,7 @@ class I2C(_BitBangIO):
         if in_end is None:
             in_end = len(buffer_in)
         if self._check_lock():
-            self._write(address, buffer[out_start:out_end], False)
+            self._write(address, buffer_out[out_start:out_end], False)
             self.readfrom_into(address, buffer_in, start=in_start, end=in_end)
 
     def _scl_low(self):


### PR DESCRIPTION
I am running on an rpi zero w using Adafruit-Blinka 6.4.0 and adafruit-circuitpython-lc709203f 2.0.2 and adafruit-circuitpython-bitbangio 1.2.4 on raspbian buster python 3.7.

I am trying to use bitbangio as I also have an SSD1306 on the normal H/W I2C ports (and it won't work with the clock stretching needed with the lc7).

Initially when trying to use the bitbangio I always got a CRC error, no matter what frequency I set for it. (I tried everything from 10KHz down to 100Hz). Looking at a logic analyzer trace it was really confused by the I2C clock timing and was unable to decipher the I2C stream correctly. I then tried the bitbang I2C on a simpler chip (the MCP23017 using mcp230xx_simpletest.py). This also failed.

Examining the code and refering to the logic traces I cleaned up the clock generation to match the I2C specs, and it now  worked with the MCP23017.

However it still did not work with the lc709203f. Again looking at the logic trace and comparing with a logic trace from the H/W I2C to the same chip I saw the difference was a stop after the write from the `writeto_then_readfrom`, which is incorrect according to the specs and the builtin bitbang in circuitpython. I modified `writeto_then_readfrom()` to disable the stop after the write by callinf ```_write()``` directly with the stop set to False.

The code now conforms very closely to the circuitpython I2C bitbang code.

The good news it now works with the  lc709203f (which is a very finicky chip), I still get CRC errors on and off but that happens with the H/W I2C as well, and maybe a different bug which I will try to track down.
(It maybe that you need to do a proper `_repeated_start` after the write).
Comparing the logic trace with that generated by the H/W I2c now looks very similar (although a whole lot slower).

The caveats are on a pizero the maximum frequency is currently around 1KHz, setting it higher simply does nothing, this is not really surprising given it is a pi zero and bit twiddling in python is not going to be very fast. Rewriting this in C may speed it up a bit. (Non blinka versions of circuit python do have a builtin c based bitbang).

Changes made....

Made the pins simulate open drain (as RPI has no open drain), by setting to input when high.
Fix clock timing issues, more in line with the circuitpython i2c bitbang.
Replaced the `time.sleep() `calls with a wait() similar to the one in the bitbang SPI.
Stop `writeto_then_readfrom()` sending a stop at the end of the write (this upsets some chips) and is incorrect (https://github.com/adafruit/circuitpython/blob/11e510a06ab67b5b78349c91d38ea780f255a425/shared-bindings/bitbangio/I2C.c#L278)

Proposed future changes...

1. Add detection of peripheral clock stretching
2. speed it up a bit (1KHz is pretty dismal)
3. The generated write clock is not symmetric, the low time being longer than the high time, this may not be an issue for most peripherals though, and may not be fixable.

