### PR TITLE
Bitbangio writes incorrectly in registers

### DIFF
--- a/adafruit_bitbangio.py
+++ b/adafruit_bitbangio.py
@@ -398,13 +398,13 @@ class SPI(_BitBangIO):
                     # Set clock to base
                     if not self._phase:  # Mode 0, 2
                         self._mosi.value = bit_value
-                    self._sclk.value = self._polarity
+                    self._sclk.value = not self._polarity
                     start_time = self._wait(start_time)
 
                     # Flip clock off base
                     if self._phase:  # Mode 1, 3
                         self._mosi.value = bit_value
-                    self._sclk.value = not self._polarity
+                    self._sclk.value = self._polarity
                     start_time = self._wait(start_time)
 
             # Return pins to base positions


### PR DESCRIPTION
in connection with https://github.com/adafruit/Adafruit_CircuitPython_BitbangIO/issues/20 tested on max31856 (phase 1) and st7735R (phase 0) on a raspberry pico/u2if. Also solves the problem of a max31856 on raspberry pi (impossible to set the thresholds)